### PR TITLE
Malformed range filter behavior change

### DIFF
--- a/Filters/Widget/Range/Range.php
+++ b/Filters/Widget/Range/Range.php
@@ -43,9 +43,9 @@ class Range extends AbstractSingleRequestValueFilter implements FieldAwareInterf
         $values = explode(';', $state->getValue(), 2);
 
         if (count($values) < 2) {
-            throw new \UnderflowException(
-                "Range request field value must contain from, to values delimited by ';', got {$state->getValue()}."
-            );
+            $state->setActive(false);
+
+            return $state;
         }
 
         $normalized['gt'] = (int)$values[0];

--- a/Tests/Functional/Filters/Widget/Range/RangeTest.php
+++ b/Tests/Functional/Filters/Widget/Range/RangeTest.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace ONGR\PagerBundle\Tests\Functional\Filters\Range;
+namespace ONGR\FilterManagerBundle\Tests\Functional\Filters\Range;
 
 use ONGR\FilterManagerBundle\Filters\Widget\Range\Range;
 use ONGR\FilterManagerBundle\Filters\Widget\Sort\Sort;
@@ -76,6 +76,9 @@ class RangeTest extends FilterManagerResultsTest
         // Case #2 no elements.
         $out[] = [new Request(['range' => '2;3', 'sort' => '0']), [], true];
 
+        // Case #3 invalid range specified.
+        $out[] = [new Request(['range' => '2', 'sort' => '0']), ['1', '2', '3', '4'], true];
+
         return $out;
     }
 
@@ -89,7 +92,7 @@ class RangeTest extends FilterManagerResultsTest
         $container = new FiltersContainer();
 
         $choices = [
-            ['label' => 'Stock ASC', 'field' => 'stock', 'order' => 'asc', 'default' => false]
+            ['label' => 'Stock ASC', 'field' => 'stock', 'order' => 'asc', 'default' => false],
         ];
 
         $filter = new Range();

--- a/Tests/Unit/Filters/Widget/Range/RangeTest.php
+++ b/Tests/Unit/Filters/Widget/Range/RangeTest.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace ONGR\PagerBundle\Tests\Unit\Filters\Range;
+namespace ONGR\FilterManagerBundle\Tests\Unit\Filters\Range;
 
 use ONGR\FilterManagerBundle\Filters\FilterState;
 use ONGR\FilterManagerBundle\Filters\Widget\Range\Range;
@@ -21,16 +21,15 @@ use Symfony\Component\HttpFoundation\Request;
 class RangeTest extends \PHPUnit_Framework_TestCase
 {
     /**
-     * Check if getState throws expected exception when state is active.
-     *
-     * @expectedException \UnderflowException
-     * @expectedExceptionMessage Range request field value must contain from, to values delimited by ';', got testValue.
+     * Check if getState returns false when parameters are malformed.
      */
     public function testGetState()
     {
         $filter = new Range();
         $filter->setRequestField('range');
-        $filter->getState(new Request(['range' => 'testValue']));
+        $state = $filter->getState(new Request(['range' => 'testValue']));
+
+        $this->assertFalse($state->isActive());
     }
 
     /**


### PR DESCRIPTION
When malformed range filter value is passed filter state is set to inactive instead of throwing exception.

Closes #9 
