### PR TITLE
Tagged filters

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -128,6 +128,10 @@ class Configuration implements ConfigurationInterface
                     ->scalarNode('field')
                         ->info('Document field name.')
                     ->end()
+                    ->arrayNode('tags')
+                        ->info('Filter tags that will be passed to view data.')
+                        ->prototype('scalar')->end()
+                    ->end()
                 ->end();
 
         switch ($filterName) {

--- a/DependencyInjection/Filter/AbstractFilterFactory.php
+++ b/DependencyInjection/Filter/AbstractFilterFactory.php
@@ -51,6 +51,12 @@ abstract class AbstractFilterFactory
                 $configuration['request_field'],
             ]
         );
+        $definition->addMethodCall(
+            'setTags',
+            [
+                $configuration['tags'],
+            ]
+        );
     }
 
     /**

--- a/Filters/FilterInterface.php
+++ b/Filters/FilterInterface.php
@@ -64,4 +64,11 @@ interface FilterInterface extends RelationsAwareInterface
      * @return ViewData
      */
     public function getViewData(DocumentIterator $result, ViewData $data);
+
+    /**
+     * Returns all tags assigned to the filter.
+     *
+     * @return array
+     */
+    public function getTags();
 }

--- a/Filters/ViewData.php
+++ b/Filters/ViewData.php
@@ -22,6 +22,11 @@ class ViewData
     private $state;
 
     /**
+     * @var array
+     */
+    private $tags;
+
+    /**
      * @var array Url parameters representing current filter state.
      */
     private $urlParameters;
@@ -82,6 +87,32 @@ class ViewData
     public function setState(FilterState $state)
     {
         $this->state = $state;
+    }
+
+    /**
+     * @return string
+     */
+    public function getTags()
+    {
+        return $this->tags;
+    }
+
+    /**
+     * @param string $tag
+     *
+     * @return bool
+     */
+    public function hasTag($tag)
+    {
+        return in_array($tag, $this->tags, true);
+    }
+
+    /**
+     * @param string $tags
+     */
+    public function setTags($tags)
+    {
+        $this->tags = $tags;
     }
 
     /**

--- a/Filters/Widget/AbstractSingleRequestValueFilter.php
+++ b/Filters/Widget/AbstractSingleRequestValueFilter.php
@@ -29,6 +29,11 @@ abstract class AbstractSingleRequestValueFilter implements FilterInterface
     private $requestField;
 
     /**
+     * @var array
+     */
+    private $tags = [];
+
+    /**
      * {@inheritdoc}
      */
     public function getState(Request $request)
@@ -59,5 +64,21 @@ abstract class AbstractSingleRequestValueFilter implements FilterInterface
     public function setRequestField($requestField)
     {
         $this->requestField = $requestField;
+    }
+
+    /**
+     * @return string
+     */
+    public function getTags()
+    {
+        return $this->tags;
+    }
+
+    /**
+     * @param string $tags
+     */
+    public function setTags($tags)
+    {
+        $this->tags = $tags;
     }
 }

--- a/Resources/doc/filter/choice.rst
+++ b/Resources/doc/filter/choice.rst
@@ -54,6 +54,8 @@ Configuration
 +------------------------+--------------------------------------------------------------------------------------+
 | `sort`                 | Sorts the choices based on your configuration.                                       |
 +------------------------+--------------------------------------------------------------------------------------+
+| `tags`                 | Array of filter specific tags that will be accessible at Twig view data.             |
++------------------------+--------------------------------------------------------------------------------------+
 
 Sorting configuration
 ---------------------
@@ -110,6 +112,10 @@ View data returned by this filter to be used in template:
 | getUrlParameters()      | Url parameters representing current filter state |
 +-------------------------+--------------------------------------------------+
 | getChoices()            | Returns a list of available choices              |
++-------------------------+--------------------------------------------------+
+| getTags()               | Lists all tags specified at filter configuration |
++-------------------------+--------------------------------------------------+
+| hasTag($tag)            | Checks if filter has the specific tag            |
 +-------------------------+--------------------------------------------------+
 
 Each choice has its own data:

--- a/Resources/doc/filter/custom_filter.rst
+++ b/Resources/doc/filter/custom_filter.rst
@@ -56,6 +56,13 @@ Class must implement ``FilterInterface``.
      */
     public function getViewData(DocumentIterator $result, ViewData $data);
 
+    /**
+     * Returns all tags assigned to the filter.
+     *
+     * @return array
+     */
+    public function getTags();
+
 
 2. Defining service
 -------------------

--- a/Resources/doc/filter/document_field.rst
+++ b/Resources/doc/filter/document_field.rst
@@ -38,6 +38,8 @@ Configuration
 +------------------------+--------------------------------------------------------------------------------------+
 | `field`                | Specifies the field in repository to apply this filter on. (e.g. `category_id`)      |
 +------------------------+--------------------------------------------------------------------------------------+
+| `tags`                 | Array of filter specific tags that will be accessible at Twig view data.             |
++------------------------+--------------------------------------------------------------------------------------+
 
 Example:
 
@@ -74,5 +76,9 @@ View data returned by this filter to be used in template:
 | getState()              | Filter state                                     |
 +-------------------------+--------------------------------------------------+
 | getUrlParameters()      | Url parameters representing current filter state |
++-------------------------+--------------------------------------------------+
+| getTags()               | Lists all tags specified at filter configuration |
++-------------------------+--------------------------------------------------+
+| hasTag($tag)            | Checks if filter has the specific tag            |
 +-------------------------+--------------------------------------------------+
 

--- a/Resources/doc/filter/match.rst
+++ b/Resources/doc/filter/match.rst
@@ -40,6 +40,8 @@ Configuration
 +------------------------+--------------------------------------------------------------------------------------+
 | `field`                | Specifies the field in repository to apply this filter on. (e.g. `item_color`)       |
 +------------------------+--------------------------------------------------------------------------------------+
+| `tags`                 | Array of filter specific tags that will be accessible at Twig view data.             |
++------------------------+--------------------------------------------------------------------------------------+
 
 Example:
 
@@ -77,6 +79,10 @@ View data returned by this filter to be used in template:
 | getState()              | Filter state                                     |
 +-------------------------+--------------------------------------------------+
 | getUrlParameters()      | Url parameters representing current filter state |
++-------------------------+--------------------------------------------------+
+| getTags()               | Lists all tags specified at filter configuration |
++-------------------------+--------------------------------------------------+
+| hasTag($tag)            | Checks if filter has the specific tag            |
 +-------------------------+--------------------------------------------------+
 
 * `Choice filter <choice.html>`_

--- a/Resources/doc/filter/multi_choice.rst
+++ b/Resources/doc/filter/multi_choice.rst
@@ -59,6 +59,8 @@ Configuration
 +------------------------+--------------------------------------------------------------------------------------------------+
 | `sort`                 | Choices can also be sorted. You can read more about this [here](choice.md#sorting-configuration).|
 +------------------------+--------------------------------------------------------------------------------------------------+
+| `tags`                 | Array of filter specific tags that will be accessible at Twig view data.                         |
++------------------------+--------------------------------------------------------------------------------------------------+
 
 Example:
 
@@ -97,6 +99,10 @@ View data returned by this filter to be used in template:
 | getUrlParameters()      | Url parameters representing current filter state |
 +-------------------------+--------------------------------------------------+
 | getChoices()            | Returns a list of available choices              |
++-------------------------+--------------------------------------------------+
+| getTags()               | Lists all tags specified at filter configuration |
++-------------------------+--------------------------------------------------+
+| hasTag($tag)            | Checks if filter has the specific tag            |
 +-------------------------+--------------------------------------------------+
 
 Each choice has its own data:

--- a/Resources/doc/filter/pager.rst
+++ b/Resources/doc/filter/pager.rst
@@ -49,6 +49,8 @@ Configuration
 +------------------------+--------------------------------------------------------------------------------------+
 | `max_pages`            | Maximum number of pages displayed in pager at once (default `8`).                    |
 +------------------------+--------------------------------------------------------------------------------------+
+| `tags`                 | Array of filter specific tags that will be accessible at Twig view data.             |
++------------------------+--------------------------------------------------------------------------------------+
 
 Example:
 
@@ -88,4 +90,8 @@ View data returned by this filter to be used in template:
 | getUrlParameters()      | Url parameters representing current filter state |
 +-------------------------+--------------------------------------------------+
 | getPagerService()       | Returns pager service to be used in template     |
++-------------------------+--------------------------------------------------+
+| getTags()               | Lists all tags specified at filter configuration |
++-------------------------+--------------------------------------------------+
+| hasTag($tag)            | Checks if filter has the specific tag            |
 +-------------------------+--------------------------------------------------+

--- a/Resources/doc/filter/sort.rst
+++ b/Resources/doc/filter/sort.rst
@@ -45,6 +45,8 @@ First, you have to specify the request field:
 +========================+======================================================================================+
 | `request_field`        | Request field used to pass the sort choice id (e.g. `www.page.com/?request_field=4`) |
 +------------------------+--------------------------------------------------------------------------------------+
+| `tags`                 | Array of filter specific tags that will be accessible at Twig view data.             |
++------------------------+--------------------------------------------------------------------------------------+
 
 After which you can specify multiple sort options/choices:
 
@@ -101,6 +103,10 @@ View data returned by this filter to be used in template:
 | getUrlParameters()      | Url parameters representing current filter state |
 +-------------------------+--------------------------------------------------+
 | getChoices()            | Returns a list of available sort choices         |
++-------------------------+--------------------------------------------------+
+| getTags()               | Lists all tags specified at filter configuration |
++-------------------------+--------------------------------------------------+
+| hasTag($tag)            | Checks if filter has the specific tag            |
 +-------------------------+--------------------------------------------------+
 
 

--- a/Search/FiltersManager.php
+++ b/Search/FiltersManager.php
@@ -149,6 +149,7 @@ class FiltersManager
             $viewData->setName($name);
             $viewData->setUrlParameters($this->composeUrlParameters($request, $filter));
             $viewData->setState($request->get($name));
+            $viewData->setTags($filter->getTags());
             $viewData->setResetUrlParameters($this->composeUrlParameters($request, $filter, [$name]));
             $out[$name] = $filter->getViewData($result, $viewData);
         }

--- a/Tests/Functional/DependencyInjection/ServiceCreationTest.php
+++ b/Tests/Functional/DependencyInjection/ServiceCreationTest.php
@@ -50,6 +50,7 @@ class ServiceCreationTest extends ElasticsearchTestCase
                 [
                     'getField' => 'price',
                     'getRequestField' => 'range',
+                    'getTags' => ['badged', 'permanent'],
                 ],
             ],
             [
@@ -58,6 +59,7 @@ class ServiceCreationTest extends ElasticsearchTestCase
                 [
                     'getField' => 'choice',
                     'getRequestField' => 'choice',
+                    'getTags' => ['badged'],
                 ],
             ],
             [

--- a/Tests/Functional/Filters/Widget/Choice/MultiTermChoiceTest.php
+++ b/Tests/Functional/Filters/Widget/Choice/MultiTermChoiceTest.php
@@ -92,6 +92,7 @@ class MultiTermChoiceTest extends AbstractFilterManagerResultsTest
 
         $filter = new MultiTermChoice();
         $filter->setRequestField('choice');
+        $filter->setTags(['badged']);
         $filter->setField('color');
         $container->set('choice', $filter);
 
@@ -182,6 +183,7 @@ class MultiTermChoiceTest extends AbstractFilterManagerResultsTest
             }
         }
 
+        $this->assertTrue($viewData->hasTag('badged'));
         $this->assertEquals($expectedUrlParams, $actualUrls);
     }
 }

--- a/Tests/Functional/Filters/Widget/Choice/SingleTermChoiceTest.php
+++ b/Tests/Functional/Filters/Widget/Choice/SingleTermChoiceTest.php
@@ -139,6 +139,7 @@ class SingleTermChoiceTest extends ElasticsearchTestCase
 
         $filter = new SingleTermChoice();
         $filter->setRequestField('choice');
+        $filter->setTags(['tagged']);
         $filter->setField('color');
         $filter->setSortType($sortParams);
 
@@ -155,6 +156,7 @@ class SingleTermChoiceTest extends ElasticsearchTestCase
             $actualChoices[] = $choice->getLabel();
         }
 
+        $this->assertFalse($result->hasTag('badged'));
         $this->assertEquals($expectedChoices, $actualChoices);
     }
 }

--- a/Tests/Unit/DependencyInjection/ConfigurationTest.php
+++ b/Tests/Unit/DependencyInjection/ConfigurationTest.php
@@ -47,22 +47,24 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
                                 'exclude' => ['size'],
                             ],
                         ],
+                        'tags' => [],
                     ],
                 ],
                 'sort' => [
                     'sorting' => [
                         'request_field' => 'sort',
                         'choices' => [],
+                        'tags' => [],
                     ],
                 ],
                 'pager' => [
-                    'paging' => ['request_field' => 'page'],
+                    'paging' => ['request_field' => 'page', 'tags' => []],
                 ],
                 'range' => [
-                    'range' => ['request_field' => 'range'],
+                    'range' => ['request_field' => 'range', 'tags' => []],
                 ],
                 'choice' => [
-                    'single_choice' => ['request_field' => 'choice'],
+                    'single_choice' => ['request_field' => 'choice', 'tags' => ['badged']],
                 ],
             ],
         ];
@@ -82,7 +84,9 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
         $expectedBaseConfig['filters']['pager']['paging']['count_per_page'] = 10;
         $expectedBaseConfig['filters']['pager']['paging']['max_pages'] = 8;
         $expectedBaseConfig['filters']['document_field'] = [];
-        $expectedBaseConfig['filters']['choice'] = ['single_choice' => ['request_field' => 'choice']];
+        $expectedBaseConfig['filters']['choice'] = [
+            'single_choice' => ['request_field' => 'choice', 'tags' => ['badged']],
+        ];
         $expectedBaseConfig['filters']['multi_choice'] = [];
         $expectedBaseConfig['filters']['fuzzy'] = [];
 
@@ -105,7 +109,7 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
         $customConfig = $expectedBaseConfig;
         $customConfig['filters']['sort']['sorting']['choices'][0] = ['field' => 'test'];
         $expectedConfig = $customConfig;
-        $expectedConfig['filters']['choice'] = ['single_choice' => ['request_field' => 'choice']];
+        $expectedConfig['filters']['choice'] = ['single_choice' => ['request_field' => 'choice', 'tags' => ['badged']]];
         $expectedConfig['filters']['sort']['sorting']['choices'][0]['label'] = 'test';
         $expectedConfig['filters']['sort']['sorting']['choices'][0]['default'] = false;
         $expectedConfig['filters']['sort']['sorting']['choices'][0]['order'] = 'asc';

--- a/Tests/Unit/DependencyInjection/ConfigurationTest.php
+++ b/Tests/Unit/DependencyInjection/ConfigurationTest.php
@@ -64,7 +64,7 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
                     'range' => ['request_field' => 'range', 'tags' => []],
                 ],
                 'date_range' => [
-                    'date' => ['request_field' => 'date_range', 'field' => 'date'],
+                    'date' => ['request_field' => 'date_range', 'field' => 'date', 'tags' => []],
                 ],
                 'choice' => [
                     'single_choice' => ['request_field' => 'choice', 'tags' => ['badged']],

--- a/Tests/Unit/DependencyInjection/ONGRFilterManagerExtensionTest.php
+++ b/Tests/Unit/DependencyInjection/ONGRFilterManagerExtensionTest.php
@@ -215,6 +215,7 @@ class ONGRFilterManagerExtensionTest extends \PHPUnit_Framework_TestCase
             'field' => 'page_field',
             'count_per_page' => 10,
             'max_pages' => 8,
+            'tags' => [],
         ];
 
         $config['ongr_filter_manager']['filters'] = [

--- a/Tests/app/config/config_test.yml
+++ b/Tests/app/config/config_test.yml
@@ -63,11 +63,16 @@ ongr_filter_manager:
             range:
                 request_field: 'range'
                 field: 'price'
+                tags:
+                    - badged
+                    - permanent
         multi_choice:
             choice:
                 request_field: 'choice'
                 field: 'choice'
                 size: 2
+                tags:
+                    - badged
         choice:
             single_choice:
                 request_field: 'single_choice'


### PR DESCRIPTION
Filters can be tagged. These tags will be accessible at view data.
Possible use cases:
* only filters with special tags are visible at sidebar or top panel;
* do not allow to deactivate filters with specific tag;
* and so on...