### PR TITLE
Sort by multiple fields

### DIFF
--- a/Filters/Widget/Sort/Sort.php
+++ b/Filters/Widget/Sort/Sort.php
@@ -37,14 +37,16 @@ class Sort extends AbstractSingleRequestValueFilter implements ViewDataFactoryIn
     public function modifySearch(Search $search, FilterState $state = null, SearchRequest $request = null)
     {
         if ($state && $state->isActive()) {
-            $search->addSort(
-                new EsSort(
-                    $this->choices[$state->getValue()]['field'],
-                    $this->choices[$state->getValue()]['order'],
-                    null,
-                    $this->choices[$state->getValue()]['mode']
-                )
-            );
+            $stateValue = $state->getValue();
+
+            if (!empty($this->choices[$stateValue]['fields'])) {
+                foreach ($this->choices[$stateValue]['fields'] as $sortField) {
+                    $search->addSort(new EsSort($sortField['field'], $sortField['order'], null, $sortField['mode']));
+                }
+            } else {
+                $sortField = $this->choices[$stateValue];
+                $search->addSort(new EsSort($sortField['field'], $sortField['order'], null, $sortField['mode']));
+            }
         } else {
             foreach ($this->choices as $choice) {
                 if ($choice['default']) {

--- a/Resources/doc/filter/sort.rst
+++ b/Resources/doc/filter/sort.rst
@@ -63,6 +63,22 @@ After which you can specify multiple sort options/choices:
 +------------------------+--------------------------------------------------------------------+
 | `mode`                 | For any arrays: `min`, `max`, for numeric arrays `avg`, `sum`.     |
 +------------------------+--------------------------------------------------------------------+
+| `fields`               | Array of fields to sort on. For more information see table below.  |
++------------------------+--------------------------------------------------------------------+
+
+.. note:: `field`, `order`, and `mode` are ignored if at least one of fields is defined.
+
+Each object in `fields` array specifies sorting condition. Available parameters are defined below:
+
++------------------------+--------------------------------------------------------------------+
+| Setting name           | Meaning                                                            |
++========================+====================================================================+
+| `field`                | Specifies the field in repository to sort on. (e.g. `item_color`)  |
++------------------------+--------------------------------------------------------------------+
+| `order`                | Order to sort by. Default `asc`. Valid values: `asc`,  `desc`.     |
++------------------------+--------------------------------------------------------------------+
+| `mode`                 | For any arrays: `min`, `max`, for numeric arrays `avg`, `sum`.     |
++------------------------+--------------------------------------------------------------------+
 
 Example:
 
@@ -83,6 +99,7 @@ Example:
                     choices:
                         - { label: Color ascending, field: item_color, default: true }
                         - { label: Color descending, field: item_color, order: desc }
+                        - { label: 'In stock & cheap', fields: [{field: stock, order: desc}, {field: price}] }
 
 ..
 

--- a/Tests/Unit/DependencyInjection/ConfigurationTest.php
+++ b/Tests/Unit/DependencyInjection/ConfigurationTest.php
@@ -117,6 +117,34 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
         $expectedConfig['filters']['sort']['sorting']['choices'][0]['default'] = false;
         $expectedConfig['filters']['sort']['sorting']['choices'][0]['order'] = 'asc';
         $expectedConfig['filters']['sort']['sorting']['choices'][0]['mode'] = null;
+        $expectedConfig['filters']['sort']['sorting']['choices'][0]['fields'][0]['field'] = 'test';
+        $expectedConfig['filters']['sort']['sorting']['choices'][0]['fields'][0]['order'] = 'asc';
+        $expectedConfig['filters']['sort']['sorting']['choices'][0]['fields'][0]['mode'] = null;
+        unset($customConfig['filters']['document_field']);
+        unset($customConfig['filters']['multi_choice']);
+        unset($customConfig['filters']['fuzzy']);
+        $cases[] = [
+            $customConfig,
+            $expectedConfig,
+        ];
+
+        // Case #3 sorting by multiple fields.
+        $customConfig = $expectedBaseConfig;
+        $customConfig['filters']['sort']['sorting']['choices'][0]['fields'][0]['field'] = 'price';
+        $customConfig['filters']['sort']['sorting']['choices'][0]['fields'][1]['field'] = 'date';
+        $customConfig['filters']['sort']['sorting']['choices'][0]['fields'][1]['order'] = 'desc';
+        $expectedConfig = $customConfig;
+        $expectedConfig['filters']['choice'] = ['single_choice' => ['request_field' => 'choice', 'tags' => ['badged']]];
+        $expectedConfig['filters']['sort']['sorting']['choices'][0]['label'] = 'price';
+        $expectedConfig['filters']['sort']['sorting']['choices'][0]['default'] = false;
+        $expectedConfig['filters']['sort']['sorting']['choices'][0]['order'] = 'asc';
+        $expectedConfig['filters']['sort']['sorting']['choices'][0]['mode'] = null;
+        $expectedConfig['filters']['sort']['sorting']['choices'][0]['fields'][0]['field'] = 'price';
+        $expectedConfig['filters']['sort']['sorting']['choices'][0]['fields'][0]['order'] = 'asc';
+        $expectedConfig['filters']['sort']['sorting']['choices'][0]['fields'][0]['mode'] = null;
+        $expectedConfig['filters']['sort']['sorting']['choices'][0]['fields'][1]['field'] = 'date';
+        $expectedConfig['filters']['sort']['sorting']['choices'][0]['fields'][1]['order'] = 'desc';
+        $expectedConfig['filters']['sort']['sorting']['choices'][0]['fields'][1]['mode'] = null;
         unset($customConfig['filters']['document_field']);
         unset($customConfig['filters']['multi_choice']);
         unset($customConfig['filters']['fuzzy']);
@@ -217,6 +245,14 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
             $config,
             'The value "test" is not allowed for path "ongr_filter_manager.filters.choice.single_choice.sort.type"' .
             '. Permissible values: "_term", "_count"',
+        ];
+
+        // Case #8 Sorting fields are not set.
+        $config = $this->getBaseConfiguration();
+        $config['filters']['sort']['sorting']['choices'][0]['label'] = 'test';
+        $cases[] = [
+            $config,
+            'The child node "fields" at path "ongr_filter_manager.filters.sort.sorting.choices.0" must be configured.',
         ];
 
         return $cases;

--- a/Tests/app/config/config_test.yml
+++ b/Tests/app/config/config_test.yml
@@ -102,3 +102,4 @@ ongr_filter_manager:
                 request_field: 'sort'
                 choices:
                     - { label: foo, field: price, default: true, order: asc }
+                    - { label: bar, fields: [{field: price, order: asc}, {field: date, order: desc}]}


### PR DESCRIPTION
Does not break backward compatibility. Works with single field as well as with multiple fields.
```
- { label: foo, field: price, default: true, order: asc }
- { label: bar, fields: [{field: price, order: asc}, {field: date, order: desc}]}
```