### PR TITLE
ElasticSearchBundle version updated for new deprecations in symfony 2.7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "require": {
         "php": ">=5.4",
         "symfony/symfony": "~2.6",
-        "ongr/elasticsearch-bundle": "~0.9"
+        "ongr/elasticsearch-bundle": ">=0.9.2"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.1",


### PR DESCRIPTION
Solution for #90
Without this fix all builds fail on travis.