### PR TITLE
Single and multi term choices takes all available options

### DIFF
--- a/Filters/Widget/Choice/SingleTermChoice.php
+++ b/Filters/Widget/Choice/SingleTermChoice.php
@@ -77,10 +77,8 @@ class SingleTermChoice extends AbstractSingleRequestValueFilter implements Field
         if ($this->getSortType()) {
             $aggregation->setOrder($this->getSortType()['type'], $this->getSortType()['order']);
         }
-        
-        if ($this->getSize()) {
-            $aggregation->setSize($this->getSize());
-        }
+
+        $aggregation->setSize($this->getSize() > 0 ? $this->getSize() : 0);
 
         if ($relatedSearch->getPostFilters()) {
             $filterAggregation = new FilterAggregation($name . '-filter');

--- a/Filters/Widget/Choice/SingleTermChoice.php
+++ b/Filters/Widget/Choice/SingleTermChoice.php
@@ -78,7 +78,10 @@ class SingleTermChoice extends AbstractSingleRequestValueFilter implements Field
             $aggregation->setOrder($this->getSortType()['type'], $this->getSortType()['order']);
         }
 
-        $aggregation->setSize($this->getSize() > 0 ? $this->getSize() : 0);
+        $aggregation->setSize(0);
+        if ($this->getSize() > 0) {
+            $aggregation->setSize($this->getSize());
+        }
 
         if ($relatedSearch->getPostFilters()) {
             $filterAggregation = new FilterAggregation($name . '-filter');

--- a/Tests/Functional/Filters/Widget/Choice/SingleTermChoiceTest.php
+++ b/Tests/Functional/Filters/Widget/Choice/SingleTermChoiceTest.php
@@ -33,36 +33,67 @@ class SingleTermChoiceTest extends ElasticsearchTestCase
                         '_id' => 1,
                         'color' => 'red',
                         'manufacturer' => 'a',
+                        'title' => 'm1',
                     ],
                     [
                         '_id' => 2,
                         'color' => 'blue',
                         'manufacturer' => 'a',
+                        'title' => 'm2',
                     ],
                     [
                         '_id' => 3,
                         'color' => 'red',
                         'manufacturer' => 'b',
+                        'title' => 'm3',
                     ],
                     [
                         '_id' => 4,
                         'color' => 'blue',
                         'manufacturer' => 'b',
+                        'title' => 'm4',
                     ],
                     [
                         '_id' => 5,
                         'color' => 'green',
                         'manufacturer' => 'b',
+                        'title' => 'm5',
                     ],
                     [
                         '_id' => 6,
                         'color' => 'blue',
                         'manufacturer' => 'a',
+                        'title' => 'm6',
                     ],
                     [
                         '_id' => 7,
                         'color' => 'yellow',
                         'manufacturer' => 'a',
+                        'title' => 'm7',
+                    ],
+                    [
+                        '_id' => 8,
+                        'color' => 'red',
+                        'manufacturer' => 'a',
+                        'title' => 'm8',
+                    ],
+                    [
+                        '_id' => 9,
+                        'color' => 'blue',
+                        'manufacturer' => 'a',
+                        'title' => 'm9',
+                    ],
+                    [
+                        '_id' => 10,
+                        'color' => 'red',
+                        'manufacturer' => 'a',
+                        'title' => 'm10',
+                    ],
+                    [
+                        '_id' => 11,
+                        'color' => 'blue',
+                        'manufacturer' => 'a',
+                        'title' => 'm11',
                     ],
                 ],
             ],
@@ -158,5 +189,26 @@ class SingleTermChoiceTest extends ElasticsearchTestCase
 
         $this->assertFalse($result->hasTag('badged'));
         $this->assertEquals($expectedChoices, $actualChoices);
+    }
+
+    /**
+     * Check if fetches more choices than ES default.
+     */
+    public function testChoicesSize()
+    {
+        $container = new FiltersContainer();
+
+        $filter = new SingleTermChoice();
+        $filter->setRequestField('choice');
+        $filter->setField('title');
+
+        $container->set('choice', $filter);
+
+        $manager = new FiltersManager($container, $this->getManager()->getRepository('AcmeTestBundle:Product'));
+
+        /** @var ChoicesAwareViewData $result */
+        $result = $manager->execute(new Request())->getFilters()['choice'];
+
+        $this->assertEquals(11, count($result->getChoices()));
     }
 }


### PR DESCRIPTION
By default single and multi term choices should take all available options instead of 10 (ES default).