### PR TITLE
Mode should not be required for sort.

### DIFF
--- a/Filters/Widget/Sort/Sort.php
+++ b/Filters/Widget/Sort/Sort.php
@@ -84,7 +84,9 @@ class Sort extends AbstractSingleRequestValueFilter implements ViewDataFactoryIn
             $viewChoice = new ViewData\Choice();
             $viewChoice->setLabel($choice['label']);
             $viewChoice->setDefault($choice['default']);
-            $viewChoice->setMode($choice['mode']);
+            if (isset($choice['mode'])) {
+                $viewChoice->setMode($choice['mode']);
+            }
             $viewChoice->setActive($active);
             if ($active) {
                 $viewChoice->setUrlParameters($data->getResetUrlParameters());

--- a/Filters/Widget/Sort/Sort.php
+++ b/Filters/Widget/Sort/Sort.php
@@ -41,20 +41,15 @@ class Sort extends AbstractSingleRequestValueFilter implements ViewDataFactoryIn
 
             if (!empty($this->choices[$stateValue]['fields'])) {
                 foreach ($this->choices[$stateValue]['fields'] as $sortField) {
-                    $search->addSort(
-                        new FieldSort($sortField['field'], $sortField['order'], ['mode' => $sortField['mode']])
-                    );
+                    $this->addFieldToSort($search, $sortField);
                 }
             } else {
-                $sortField = $this->choices[$stateValue];
-                $search->addSort(
-                    new FieldSort($sortField['field'], $sortField['order'], ['mode' => $sortField['mode']])
-                );
+                $this->addFieldToSort($search, $this->choices[$stateValue]);
             }
         } else {
             foreach ($this->choices as $choice) {
                 if ($choice['default']) {
-                    $search->addSort(new FieldSort($choice['field'], $choice['order']));
+                    $this->addFieldToSort($search, $choice);
 
                     break;
                 }
@@ -126,5 +121,22 @@ class Sort extends AbstractSingleRequestValueFilter implements ViewDataFactoryIn
         $parameters[$this->getRequestField()] = $key;
 
         return $parameters;
+    }
+
+    /**
+     * Adds sort field parameters into given search object.
+     *
+     * @param Search $search
+     * @param array  $sortField
+     */
+    private function addFieldToSort(Search $search, $sortField)
+    {
+        $search->addSort(
+            new FieldSort(
+                $sortField['field'],
+                $sortField['order'],
+                isset($sortField['mode']) ? ['mode' => $sortField['mode']] : []
+            )
+        );
     }
 }

--- a/Tests/Unit/Filters/Widget/Sort/SortTest.php
+++ b/Tests/Unit/Filters/Widget/Sort/SortTest.php
@@ -20,14 +20,16 @@ class SortTest extends \PHPUnit_Framework_TestCase
     public function testWithoutMode()
     {
         $filter = new Sort();
-        $filter->setChoices([
-            'default' => [
-                'label'   => 'default sorting',
-                'field'   => 'name',
-                'order'   => 'asc',
-                'default' => true,
+        $filter->setChoices(
+            [
+                'default' => [
+                    'label' => 'default sorting',
+                    'field' => 'name',
+                    'order' => 'asc',
+                    'default' => true,
+                ],
             ]
-        ]);
+        );
         $filter->setRequestField('sort');
 
         $state = new FilterState();

--- a/Tests/Unit/Filters/Widget/Sort/SortTest.php
+++ b/Tests/Unit/Filters/Widget/Sort/SortTest.php
@@ -10,7 +10,7 @@ use ONGR\FilterManagerBundle\Search\SearchRequest;
 use Symfony\Component\HttpFoundation\Request;
 
 /**
- * Class SortTest
+ * Unit test for sorting.
  **/
 class SortTest extends \PHPUnit_Framework_TestCase
 {

--- a/Tests/Unit/Filters/Widget/Sort/SortTest.php
+++ b/Tests/Unit/Filters/Widget/Sort/SortTest.php
@@ -2,9 +2,13 @@
 
 namespace ONGR\FilterManagerBundle\Tests\Unit\Filters\Widget\Sort;
 
+use ONGR\ElasticsearchBundle\Result\DocumentIterator;
+use ONGR\ElasticsearchBundle\Service\Manager;
+use ONGR\ElasticsearchBundle\Service\Repository;
 use ONGR\ElasticsearchDSL\Search;
 use ONGR\ElasticsearchDSL\Sort\FieldSort;
 use ONGR\FilterManagerBundle\Filters\FilterState;
+use ONGR\FilterManagerBundle\Filters\ViewData;
 use ONGR\FilterManagerBundle\Filters\Widget\Sort\Sort;
 use ONGR\FilterManagerBundle\Search\SearchRequest;
 use Symfony\Component\HttpFoundation\Request;
@@ -38,5 +42,24 @@ class SortTest extends \PHPUnit_Framework_TestCase
 
         $modifiedSearch = new Search();
         $filter->modifySearch($modifiedSearch, $state, new SearchRequest(['sort' => 'default']));
+
+        $documentIterator = $this
+            ->getMockBuilder('ONGR\ElasticsearchBundle\Result\DocumentIterator')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $viewData = $this
+            ->getMockBuilder('ONGR\FilterManagerBundle\Filters\ViewData')
+            ->setMethods(['getState', 'addChoice'])
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $viewData
+            ->expects($this->any())
+            ->method('getState')
+            ->willReturn($state);
+
+
+        $filter->getViewData($documentIterator, $viewData);
     }
 }

--- a/Tests/Unit/Filters/Widget/Sort/SortTest.php
+++ b/Tests/Unit/Filters/Widget/Sort/SortTest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace ONGR\FilterManagerBundle\Tests\Unit\Filters\Widget\Sort;
+
+use ONGR\ElasticsearchDSL\Search;
+use ONGR\ElasticsearchDSL\Sort\FieldSort;
+use ONGR\FilterManagerBundle\Filters\FilterState;
+use ONGR\FilterManagerBundle\Filters\Widget\Sort\Sort;
+use ONGR\FilterManagerBundle\Search\SearchRequest;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * Class SortTest
+ **/
+class SortTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * Checks if sort filter handles missing mode without exceptions.
+     */
+    public function testWithoutMode()
+    {
+        $filter = new Sort();
+        $filter->setChoices([
+            'default' => [
+                'label'   => 'default sorting',
+                'field'   => 'name',
+                'order'   => 'asc',
+                'default' => true,
+            ]
+        ]);
+        $filter->setRequestField('sort');
+
+        $state = new FilterState();
+        $state->setActive(true);
+        $state->setValue('default');
+
+        $modifiedSearch = new Search();
+        $filter->modifySearch($modifiedSearch, $state, new SearchRequest(['sort' => 'default']));
+    }
+}


### PR DESCRIPTION
Previously if no mode was provided for sort choice PHP notice were thrown because there is no check at https://github.com/ongr-io/FilterManagerBundle/blob/2c4ff45f0c42b1c842e4cd38dc703b87d82f8586/Filters/Widget/Sort/Sort.php#L45 and several other places. Mode itself was optional see: https://github.com/ongr-io/FilterManagerBundle/blob/90b3c54aab292ff9917bcf3cc34a81e4f00fca6c/DependencyInjection/Configuration.php#L193-193

This PR adds check and prevents notices from breaking application.