### PR TITLE
Fixed | Cannot load Twig Environment in Twig\PagerExtension

### DIFF
--- a/Search/FiltersManager.php
+++ b/Search/FiltersManager.php
@@ -66,7 +66,7 @@ class FiltersManager implements FiltersManagerInterface
     {
         $search = $this->container->buildSearch($request);
 
-        /** @var FilterInterface[] $filters */
+        /** @var FilterInterface $filter */
         foreach ($this->container->all() as $name => $filter) {
             // We simply exclude not related filters and current filter itself.
             $relatedFilters = $this->container->getFiltersByRelation(

--- a/Tests/Unit/Twig/PagerExtensionTest.php
+++ b/Tests/Unit/Twig/PagerExtensionTest.php
@@ -73,7 +73,7 @@ class PagerExtensionTest extends \PHPUnit_Framework_TestCase
         $parameters = [];
         $template = 'tpl';
 
-        $result = $this->pagerExtension->paginate($pager, $route, $parameters, $template);
+        $result = $this->pagerExtension->paginate($twigEnvironment, $pager, $route, $parameters, $template);
         $this->assertNotEmpty($result);
     }
 

--- a/Twig/PagerExtension.php
+++ b/Twig/PagerExtension.php
@@ -56,7 +56,8 @@ class PagerExtension extends \Twig_Extension
     public function getFunctions()
     {
         return [
-            new \Twig_SimpleFunction('ongr_paginate', [$this, 'paginate'], ['is_safe' => ['html']]),
+            new \Twig_SimpleFunction('ongr_paginate', [$this, 'paginate'],
+                ['is_safe' => ['html'], 'needs_environment' => true]),
             new \Twig_SimpleFunction('ongr_paginate_path', [$this, 'path'], ['is_safe' => []]),
         ];
     }
@@ -64,20 +65,23 @@ class PagerExtension extends \Twig_Extension
     /**
      * Renders pagination element.
      *
-     * @param PagerService $pager
-     * @param string       $route
-     * @param array        $parameters
-     * @param string       $template
+     * @param \Twig_Environment $env
+     * @param PagerService      $pager
+     * @param string            $route
+     * @param array             $parameters
+     * @param string            $template
      *
      * @return string
      */
     public function paginate(
+        \Twig_Environment $env,
         PagerService $pager,
         $route,
         array $parameters = [],
         $template = 'ONGRFilterManagerBundle:Pager:paginate.html.twig'
     ) {
-        return $this->environment->render(
+
+        return $env->render(
             $template,
             ['pager' => $pager, 'route' => $route, 'parameters' => $parameters]
         );

--- a/Twig/PagerExtension.php
+++ b/Twig/PagerExtension.php
@@ -56,8 +56,11 @@ class PagerExtension extends \Twig_Extension
     public function getFunctions()
     {
         return [
-            new \Twig_SimpleFunction('ongr_paginate', [$this, 'paginate'],
-                ['is_safe' => ['html'], 'needs_environment' => true]),
+            new \Twig_SimpleFunction(
+                'ongr_paginate',
+                [$this, 'paginate'],
+                ['is_safe' => ['html'], 'needs_environment' => true]
+            ),
             new \Twig_SimpleFunction('ongr_paginate_path', [$this, 'path'], ['is_safe' => []]),
         ];
     }


### PR DESCRIPTION
I approached the latest version of ONGR via DEMO, and the Product List page didn't work properly with the Pagination function. So I fixed it.