### PR TITLE
Symfony 3 support

### DIFF
--- a/DependencyInjection/ONGRFilterManagerExtension.php
+++ b/DependencyInjection/ONGRFilterManagerExtension.php
@@ -149,7 +149,7 @@ class ONGRFilterManagerExtension extends Extension
             }
 
             $managerDefinition = new Definition(
-                $container->getParameter('ongr_filter_manager.search.filters_manager.class'),
+                'ONGR\FilterManagerBundle\Search\FiltersManager',
                 [
                     $filtersContainer,
                     new Reference($manager['repository']),

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -1,10 +1,6 @@
-parameters:
-    ongr_filter_manager.twig.pager_extension.class: ONGR\FilterManagerBundle\Twig\PagerExtension
-    ongr_filter_manager.search.filters_manager.class: ONGR\FilterManagerBundle\Search\FiltersManager
-
 services:
     ongr_filter_manager.twig.pager_extension:
-            class: %ongr_filter_manager.twig.pager_extension.class%
+            class: ONGR\FilterManagerBundle\Twig\PagerExtension
             arguments:
                 - '@router'
             tags:

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -6,6 +6,6 @@ services:
     ongr_filter_manager.twig.pager_extension:
             class: %ongr_filter_manager.twig.pager_extension.class%
             arguments:
-                - @router
+                - '@router'
             tags:
                 - { name: twig.extension }


### PR DESCRIPTION
In order to work with Symfony ~3.0 all services should be in quotes.
Class parameters removed as well.