### PR TITLE
Require coveralls package only on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,13 @@ php:
   - 5.6
   - 7.0
   - hhvm
-services:
-  - elasticsearch
 matrix:
   allow_failures:
     - php: hhvm
+services:
+  - elasticsearch
+install:
+  - composer require --dev --no-update --no-interaction satooshi/php-coveralls
 before_script:
   - composer config -g github-oauth.github.com $GITHUB_COMPOSER_AUTH
   - composer install --no-interaction

--- a/composer.json
+++ b/composer.json
@@ -18,8 +18,7 @@
     "require-dev": {
         "monolog/monolog": "~1.0",
         "phpunit/phpunit": "~4.4",
-        "squizlabs/php_codesniffer": "~2.4",
-        "satooshi/php-coveralls": "dev-master"
+        "squizlabs/php_codesniffer": "~2.4"
     },
     "autoload": {
         "psr-4": { "ONGR\\FilterManagerBundle\\": "" }


### PR DESCRIPTION
We should not include coveralls in `composer.json`.

The same applies for all packages.