### PR TITLE
Improvements for Range filter

### DIFF
--- a/Filter/Widget/Range/Range.php
+++ b/Filter/Widget/Range/Range.php
@@ -45,8 +45,15 @@ class Range extends AbstractRange
         $gt = $this->isInclusive() ? 'gte' : 'gt';
         $lt = $this->isInclusive() ? 'lte' : 'lt';
 
-        $normalized[$gt] = floatval($values[0]);
-        $normalized[$lt] = floatval($values[1]);
+        $normalized = [];
+        $values[0] == '-' ? : $normalized[$gt] = floatval($values[0]);
+        $values[1] == '-' ? : $normalized[$lt] = floatval($values[1]);
+
+        if (empty($normalized)) {
+            $state->setActive(false);
+
+            return $state;
+        }
 
         $state->setValue($normalized);
 

--- a/Resources/doc/filter/range.md
+++ b/Resources/doc/filter/range.md
@@ -30,6 +30,12 @@ ongr_filter_manager:
                 inclusive: true
 ```
 
+When using this filter, `request_field` GET parameters need to be provided as two numbers separated 
+by `;`. For example, to search for values between 10 and 20 you would need to provide a URL like this:
+`www.page.com/?request_field=10;20`. If there is no specific value, that is, all the values that are
+ grater than 100 need to be provided, `-` must be specified in stead of a number:
+`www.page.com/?request_field=100;-`.
+
 ## Twig view data
 
 View data returned by this filter to be used in template:

--- a/Tests/Functional/Filter/Widget/Range/RangeTest.php
+++ b/Tests/Functional/Filter/Widget/Range/RangeTest.php
@@ -138,6 +138,30 @@ class RangeTest extends AbstractFilterManagerResultsTest
             'managers' => $managers,
         ];
 
+        // Case #8 only to range specified.
+        $out[] = [
+            'request' => new Request(['range' => '-;3', 'sort' => '0', 'mode' => null]),
+            'ids' => ['1', '2'],
+            'assertOrder' => true,
+            'managers' => $managers,
+        ];
+
+        // Case #9 only from range specified.
+        $out[] = [
+            'request' => new Request(['range' => '2;-', 'sort' => '0', 'mode' => null]),
+            'ids' => ['3', '4', '5'],
+            'assertOrder' => true,
+            'managers' => $managers,
+        ];
+
+        // Case #10 any range specified.
+        $out[] = [
+            'request' => new Request(['range' => '-;-', 'sort' => '0', 'mode' => null]),
+            'ids' => ['1', '2', '3', '4', '5'],
+            'assertOrder' => true,
+            'managers' => $managers,
+        ];
+
         return $out;
     }
 

--- a/Tests/app/fixture/TestBundle/Filter/FooRange/FooRange.php
+++ b/Tests/app/fixture/TestBundle/Filter/FooRange/FooRange.php
@@ -60,8 +60,15 @@ class FooRange extends AbstractSingleRequestValueFilter implements FieldAwareInt
             return $state;
         }
 
-        $normalized['gt'] = floatval($values[0]);
-        $normalized['lt'] = floatval($values[1]);
+        $normalized = [];
+        $values[0] == '-' ? : $normalized['gt'] = floatval($values[0]);
+        $values[1] == '-' ? : $normalized['lt'] = floatval($values[1]);
+
+        if (empty($normalized)) {
+            $state->setActive(false);
+
+            return $state;
+        }
 
         $state->setValue($normalized);
 


### PR DESCRIPTION
My suggestion for the implementation of the improvements for Range filter. With this it is now possible to specify a range like this - `range=-;13` or `range=5;-`.

closes #182 #181
