### PR TITLE
Implemented a check if relatedSearch is required

### DIFF
--- a/Filter/FilterInterface.php
+++ b/Filter/FilterInterface.php
@@ -71,4 +71,12 @@ interface FilterInterface extends RelationAwareInterface
      * @return array
      */
     public function getTags();
+
+    /**
+     * Defines whether its necessary to build a related search for
+     * the filters preProcessSearch() method
+     *
+     * @return bool
+     */
+    public function isRelated();
 }

--- a/Filter/Widget/Choice/SingleTermChoice.php
+++ b/Filter/Widget/Choice/SingleTermChoice.php
@@ -135,6 +135,14 @@ class SingleTermChoice extends AbstractSingleRequestValueFilter implements Field
     }
 
     /**
+     * {@inheritdoc}
+     */
+    public function isRelated()
+    {
+        return true;
+    }
+
+    /**
      * Adds prioritized choices.
      *
      * @param array                $unsortedChoices

--- a/Filter/Widget/Pager/Pager.php
+++ b/Filter/Widget/Pager/Pager.php
@@ -137,4 +137,12 @@ class Pager extends AbstractSingleRequestValueFilter implements FilterInterface,
 
         return $data;
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isRelated()
+    {
+        return false;
+    }
 }

--- a/Filter/Widget/Range/AbstractRange.php
+++ b/Filter/Widget/Range/AbstractRange.php
@@ -73,4 +73,12 @@ abstract class AbstractRange extends AbstractSingleRequestValueFilter implements
             $search->addPostFilter($filter);
         }
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isRelated()
+    {
+        return false;
+    }
 }

--- a/Filter/Widget/Search/AbstractSingleValue.php
+++ b/Filter/Widget/Search/AbstractSingleValue.php
@@ -41,4 +41,12 @@ abstract class AbstractSingleValue extends AbstractSingleRequestValueFilter impl
     {
         // Nothing more to do here.
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isRelated()
+    {
+        return false;
+    }
 }

--- a/Filter/Widget/Sort/Sort.php
+++ b/Filter/Widget/Sort/Sort.php
@@ -112,6 +112,14 @@ class Sort extends AbstractSingleRequestValueFilter implements ViewDataFactoryIn
     }
 
     /**
+     * {@inheritdoc}
+     */
+    public function isRelated()
+    {
+        return false;
+    }
+
+    /**
      * @param string   $key
      * @param ViewData $data
      *

--- a/Tests/Unit/Search/FilterManagerTest.php
+++ b/Tests/Unit/Search/FilterManagerTest.php
@@ -31,6 +31,9 @@ class FilterManagerTest extends \PHPUnit_Framework_TestCase
         $mockFilterInterface->expects($this->once())
             ->method('preProcessSearch');
         $mockFilterInterface->expects($this->once())
+            ->method('isRelated')
+            ->will($this->returnValue(true));
+        $mockFilterInterface->expects($this->once())
             ->method('getSearchRelation')
             ->will($this->returnValue(null));
 

--- a/Tests/app/fixture/TestBundle/Filter/FooRange/FooRange.php
+++ b/Tests/app/fixture/TestBundle/Filter/FooRange/FooRange.php
@@ -108,4 +108,12 @@ class FooRange extends AbstractSingleRequestValueFilter implements FieldAwareInt
 
         return $data;
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isRelated()
+    {
+        return true;
+    }
 }


### PR DESCRIPTION
Solves the performance issue of unnecessary `relatedSearch` creation by introducing an `isRelated` method to `FilterInterface`. `isRelated` returns true only in filters that use the `relatedSearch` variable in their `preprocessSearch` methods.

closes #146 