### PR TITLE
Duplicate value aggregation fix

### DIFF
--- a/Filter/ViewData/AggregateViewData.php
+++ b/Filter/ViewData/AggregateViewData.php
@@ -46,4 +46,18 @@ class AggregateViewData extends ViewData
     {
         $this->items[] = $item;
     }
+
+    /**
+     * @param callback $callback
+     */
+    public function sortItems($callback = null)
+    {
+        if ($callback === null) {
+            $callback = function ($a, $b) {
+                return strcmp($a->getName(), $b->getName());
+            };
+        }
+
+        usort($this->items, $callback);
+    }
 }

--- a/Filter/Widget/Dynamic/DynamicAggregate.php
+++ b/Filter/Widget/Dynamic/DynamicAggregate.php
@@ -12,9 +12,9 @@
 namespace ONGR\FilterManagerBundle\Filter\Widget\Dynamic;
 
 use ONGR\ElasticsearchBundle\Result\Aggregation\AggregationValue;
-use ONGR\ElasticsearchDSL\Aggregation\FilterAggregation;
-use ONGR\ElasticsearchDSL\Aggregation\NestedAggregation;
-use ONGR\ElasticsearchDSL\Aggregation\TermsAggregation;
+use ONGR\ElasticsearchDSL\Aggregation\Bucketing\FilterAggregation;
+use ONGR\ElasticsearchDSL\Aggregation\Bucketing\NestedAggregation;
+use ONGR\ElasticsearchDSL\Aggregation\Bucketing\TermsAggregation;
 use ONGR\ElasticsearchDSL\BuilderInterface;
 use ONGR\ElasticsearchDSL\Query\BoolQuery;
 use ONGR\ElasticsearchDSL\Query\MatchAllQuery;
@@ -100,7 +100,7 @@ class DynamicAggregate extends AbstractFilter implements ViewDataFactoryInterfac
      */
     public function preProcessSearch(Search $search, Search $relatedSearch, FilterState $state = null)
     {
-        list($path, $field) = explode('>', $this->getField());
+        list($path, $field) = explode('>', $this->getDocumentField());
         $filter = !empty($filter = $relatedSearch->getPostFilters()) ? $filter : new MatchAllQuery();
         $aggregation = new NestedAggregation($state->getName(), $path);
         $nameAggregation = new TermsAggregation('name', $this->getNameField());
@@ -111,7 +111,7 @@ class DynamicAggregate extends AbstractFilter implements ViewDataFactoryInterfac
         $filterAggregation->setFilter($filter);
 
         if ($this->getSortType()) {
-            $valueAggregation->addParameter('order', [$this->getSortType()['type'] => $this->getSortType()['order']]);
+            $valueAggregation->addParameter('order', [$this->getSortType() => $this->getSortOrder()]);
         }
 
         if ($state->isActive()) {

--- a/Filter/Widget/Dynamic/DynamicAggregate.php
+++ b/Filter/Widget/Dynamic/DynamicAggregate.php
@@ -296,7 +296,15 @@ class DynamicAggregate extends AbstractFilter implements ViewDataFactoryInterfac
      */
     protected function isChoiceActive($key, ViewData $data, $activeName)
     {
-        return $data->getState()->isActive() && in_array($key, $data->getState()->getValue());
+        if ($data->getState()->isActive()) {
+            $value = $data->getState()->getValue();
+
+            if (isset($value[$activeName]) && $key == $value[$activeName]) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**

--- a/Filter/Widget/Dynamic/DynamicAggregate.php
+++ b/Filter/Widget/Dynamic/DynamicAggregate.php
@@ -100,30 +100,18 @@ class DynamicAggregate extends AbstractFilter implements ViewDataFactoryInterfac
      */
     public function preProcessSearch(Search $search, Search $relatedSearch, FilterState $state = null)
     {
-        list($path, $field) = explode('>', $this->getDocumentField());
-        $name = $state->getName();
-        $aggregation = new NestedAggregation(
-            $name,
-            $path
-        );
-        $termsAggregation = new TermsAggregation('query', $field);
-        $termsAggregation->addParameter('size', 0);
+        list($path, $field) = explode('>', $this->getField());
+        $filter = !empty($filter = $relatedSearch->getPostFilters()) ? $filter : new MatchAllQuery();
+        $aggregation = new NestedAggregation($state->getName(), $path);
+        $nameAggregation = new TermsAggregation('name', $this->getNameField());
+        $valueAggregation = new TermsAggregation('value', $field);
+        $filterAggregation = new FilterAggregation($state->getName() . '-filter');
+        $nameAggregation->addAggregation($valueAggregation);
+        $aggregation->addAggregation($nameAggregation);
+        $filterAggregation->setFilter($filter);
 
         if ($this->getSortType()) {
-            $termsAggregation->addParameter('order', [$this->getSortType() => $this->getSortOrder()]);
-        }
-
-        $termsAggregation->addAggregation(
-            new TermsAggregation('name', $this->getNameField())
-        );
-
-        $aggregation->addAggregation($termsAggregation);
-        $filterAggregation = new FilterAggregation($name . '-filter');
-
-        if (!empty($relatedSearch->getPostFilters())) {
-            $filterAggregation->setFilter($relatedSearch->getPostFilters());
-        } else {
-            $filterAggregation->setFilter(new MatchAllQuery());
+            $valueAggregation->addParameter('order', [$this->getSortType()['type'] => $this->getSortType()['order']]);
         }
 
         if ($state->isActive()) {
@@ -171,49 +159,32 @@ class DynamicAggregate extends AbstractFilter implements ViewDataFactoryInterfac
         $activeNames = $data->getState()->isActive() ? array_keys($data->getState()->getValue()) : [];
         $filterAggregations = $this->fetchAggregation($result, $data->getName(), $data->getState()->getValue());
 
-        if ($this->getShowZeroChoices() && $data->getState()->isActive()) {
+        if ($this->getShowZeroChoices()) {
             $unsortedChoices = $this->formInitialUnsortedChoices($result, $data);
         }
 
         /** @var AggregationValue $bucket */
         foreach ($filterAggregations as $activeName => $aggregation) {
             foreach ($aggregation as $bucket) {
-                $name = $bucket->getAggregation('name')->getBuckets()[0]['key'];
+                $name = $bucket['key'];
 
                 if ($name != $activeName && $activeName != 'all-selected') {
                     continue;
                 }
 
-                $active = $this->isChoiceActive($bucket['key'], $data, $activeName);
-                $choice = new ViewData\Choice();
-                $choice->setLabel($bucket->getValue('key'));
-                $choice->setCount($bucket['doc_count']);
-                $choice->setActive($active);
-
-                $choice->setUrlParameters(
-                    $this->getOptionUrlParameters($bucket['key'], $name, $data, $active)
-                );
-
-                if ($activeName == 'all-selected') {
-                    $unsortedChoices[$activeName][$name][$bucket['key']] = $choice;
-                } else {
-                    $unsortedChoices[$activeName][$bucket['key']] = $choice;
-                }
+                $this->addNonZeroValuesToUnsortedChoices($unsortedChoices, $activeName, $bucket, $data);
             }
         }
 
-        if (isset($unsortedChoices['all-selected'])) {
-            foreach ($unsortedChoices['all-selected'] as $name => $buckets) {
-                if (in_array($name, $activeNames)) {
-                    continue;
-                }
-
-                $unsortedChoices[$name] = $buckets;
+        foreach ($unsortedChoices['all-selected'] as $name => $buckets) {
+            if (in_array($name, $activeNames)) {
+                continue;
             }
 
-            unset($unsortedChoices['all-selected']);
+            $unsortedChoices[$name] = $buckets;
         }
 
+        unset($unsortedChoices['all-selected']);
         ksort($unsortedChoices);
 
         /** @var AggregateViewData $data */
@@ -253,10 +224,10 @@ class DynamicAggregate extends AbstractFilter implements ViewDataFactoryInterfac
         $aggregation = $result->getAggregation(sprintf('%s-filter', $filterName));
 
         foreach ($values as $name => $value) {
-            $data[$name] = $aggregation->find(sprintf('%s.%s.query', $name, $filterName));
+            $data[$name] = $aggregation->find(sprintf('%s.%s.name', $name, $filterName));
         }
 
-        $data['all-selected'] = $aggregation->find(sprintf('all-selected.%s.query', $filterName));
+        $data['all-selected'] = $aggregation->find(sprintf('all-selected.%s.name', $filterName));
 
         return $data;
     }
@@ -281,20 +252,15 @@ class DynamicAggregate extends AbstractFilter implements ViewDataFactoryInterfac
         list($path, $field) = explode('>', $this->getDocumentField());
         $boolQuery = new BoolQuery();
 
-        foreach ($terms as $term) {
-            $boolQuery->add(
-                new NestedQuery($path, new TermQuery($field, $term))
-            );
+        foreach ($terms as $groupName => $term) {
+            $nestedBoolQuery = new BoolQuery();
+            $nestedBoolQuery->add(new TermQuery($field, $term));
+            $nestedBoolQuery->add(new TermQuery($this->getNameField(), $groupName));
+            $boolQuery->add(new NestedQuery($path, $nestedBoolQuery));
         }
 
-        if ($boolQuery->getQueries() == []) {
-            $boolQuery->add(new MatchAllQuery());
-        }
-
-        $innerFilterAggregation = new FilterAggregation(
-            $aggName,
-            $boolQuery
-        );
+        $boolQuery = !empty($boolQuery->getQueries()) ? $boolQuery : new MatchAllQuery();
+        $innerFilterAggregation = new FilterAggregation($aggName, $boolQuery);
         $innerFilterAggregation->addAggregation($deepLevelAggregation);
         $filterAggregation->addAggregation($innerFilterAggregation);
     }
@@ -359,17 +325,47 @@ class DynamicAggregate extends AbstractFilter implements ViewDataFactoryInterfac
             $data->getState()->getUrlParameters()
         );
 
-        foreach ($result->getAggregation($data->getName())->getAggregation('query') as $bucket) {
-            $groupName = $bucket->getAggregation('name')->getBuckets()[0]['key'];
-            $choice = new ViewData\Choice();
-            $choice->setActive(false);
-            $choice->setUrlParameters($urlParameters);
-            $choice->setLabel($bucket['key']);
-            $choice->setCount(0);
-            $unsortedChoices[$groupName][$bucket['key']] = $choice;
-            $unsortedChoices['all-selected'][$groupName][$bucket['key']] = $choice;
+        foreach ($result->getAggregation($data->getName())->getAggregation('name') as $nameBucket) {
+            $groupName = $nameBucket['key'];
+
+            foreach ($nameBucket->getAggregation('value') as $bucket) {
+                $choice = new ViewData\Choice();
+                $choice->setActive(false);
+                $choice->setUrlParameters($urlParameters);
+                $choice->setLabel($bucket['key']);
+                $choice->setCount(0);
+                $unsortedChoices[$groupName][$bucket['key']] = $choice;
+                $unsortedChoices['all-selected'][$groupName][$bucket['key']] = $choice;
+            }
         }
 
         return $unsortedChoices;
+    }
+
+    /**
+     * @param array            $unsortedChoices
+     * @param string           $activeName
+     * @param AggregationValue $agg
+     * @param ViewData         $data
+     */
+    protected function addNonZeroValuesToUnsortedChoices(&$unsortedChoices, $activeName, $agg, $data) {
+        $name = $agg['key'];
+        foreach ($agg['value']['buckets'] as $bucket) {
+            $active = $this->isChoiceActive($bucket['key'], $data, $activeName);
+            $choice = new ViewData\Choice();
+            $choice->setLabel($bucket['key']);
+            $choice->setCount($bucket['doc_count']);
+            $choice->setActive($active);
+
+            $choice->setUrlParameters(
+                $this->getOptionUrlParameters($bucket['key'], $name, $data, $active)
+            );
+
+            if ($activeName == 'all-selected') {
+                $unsortedChoices[$activeName][$name][$bucket['key']] = $choice;
+            } else {
+                $unsortedChoices[$activeName][$bucket['key']] = $choice;
+            }
+        }
     }
 }

--- a/Filter/Widget/Dynamic/DynamicAggregate.php
+++ b/Filter/Widget/Dynamic/DynamicAggregate.php
@@ -80,13 +80,16 @@ class DynamicAggregate extends AbstractFilter implements ViewDataFactoryInterfac
 
         if ($state && $state->isActive()) {
             $boolQuery = new BoolQuery();
-            foreach ($state->getValue() as $value) {
-                $boolQuery->add(
-                    new NestedQuery(
-                        $path,
-                        new TermQuery($field, $value)
-                    )
+            foreach ($state->getValue() as $groupName => $value) {
+                $innerBoolQuery = new BoolQuery();
+                $nestedQuery = new NestedQuery($path, $innerBoolQuery);
+                $innerBoolQuery->add(
+                    new TermQuery($field, $value)
                 );
+                $innerBoolQuery->add(
+                    new TermQuery($this->getNameField(), $groupName)
+                );
+                $boolQuery->add($nestedQuery);
             }
             $search->addPostFilter($boolQuery);
         }

--- a/Filter/Widget/Dynamic/MultiDynamicAggregate.php
+++ b/Filter/Widget/Dynamic/MultiDynamicAggregate.php
@@ -134,7 +134,7 @@ class MultiDynamicAggregate extends DynamicAggregate
      */
     private function getFilterQuery($terms)
     {
-        list($path, $field) = explode('>', $this->getField());
+        list($path, $field) = explode('>', $this->getDocumentField());
         $boolQuery = new BoolQuery();
 
         foreach ($terms as $groupName => $values) {

--- a/Filter/Widget/Dynamic/MultiDynamicAggregate.php
+++ b/Filter/Widget/Dynamic/MultiDynamicAggregate.php
@@ -40,28 +40,8 @@ class MultiDynamicAggregate extends DynamicAggregate
      */
     public function modifySearch(Search $search, FilterState $state = null, SearchRequest $request = null)
     {
-        list($path, $field) = explode('>', $this->getDocumentField());
-
         if ($state && $state->isActive()) {
-            $boolQuery = new BoolQuery();
-
-            foreach ($state->getValue() as $groupName => $values) {
-                $innerBoolQuery = new BoolQuery();
-
-                foreach ($values as $value) {
-                    $innerBoolQuery->add(
-                        new NestedQuery(
-                            $path,
-                            new TermQuery($field, $value)
-                        ),
-                        BoolQuery::SHOULD
-                    );
-                }
-
-                $boolQuery->add($innerBoolQuery);
-            }
-
-            $search->addPostFilter($boolQuery);
+            $search->addPostFilter($this->getFilterQuery($state->getValue()));
         }
     }
 
@@ -82,14 +62,7 @@ class MultiDynamicAggregate extends DynamicAggregate
         $terms,
         $aggName
     ) {
-        list($path, $field) = explode('>', $this->getDocumentField());
-        $boolQuery = new BoolQuery();
-
-        foreach ($terms as $namedTerms) {
-            $boolQuery->add(
-                new NestedQuery($path, new TermsQuery($field, array_values($namedTerms)))
-            );
-        }
+        $boolQuery = $this->getFilterQuery($terms);
 
         if ($boolQuery->getQueries() == []) {
             $boolQuery->add(new MatchAllQuery());
@@ -152,5 +125,37 @@ class MultiDynamicAggregate extends DynamicAggregate
         }
 
         return false;
+    }
+
+    /**
+     * @param array $terms
+     *
+     * @return BoolQuery
+     */
+    private function getFilterQuery($terms)
+    {
+        list($path, $field) = explode('>', $this->getField());
+        $boolQuery = new BoolQuery();
+
+        foreach ($terms as $groupName => $values) {
+            $innerBoolQuery = new BoolQuery();
+
+            foreach ($values as $value) {
+                $nestedBoolQuery = new BoolQuery();
+                $nestedBoolQuery->add(new TermQuery($field, $value));
+                $nestedBoolQuery->add(new TermQuery($this->getNameField(), $groupName));
+                $innerBoolQuery->add(
+                    new NestedQuery(
+                        $path,
+                        $nestedBoolQuery
+                    ),
+                    BoolQuery::SHOULD
+                );
+            }
+
+            $boolQuery->add($innerBoolQuery);
+        }
+
+        return $boolQuery;
     }
 }

--- a/Tests/Functional/Filter/Widget/Dynamic/DynamicAggregateTest.php
+++ b/Tests/Functional/Filter/Widget/Dynamic/DynamicAggregateTest.php
@@ -39,6 +39,10 @@ class DynamicAggregateTest extends AbstractElasticsearchTestCase
                                 'value' => 'USA',
                             ],
                             [
+                                'name' => 'Designed in',
+                                'value' => 'USA',
+                            ],
+                            [
                                 'name' => 'Color',
                                 'value' => 'Green',
                             ],
@@ -77,6 +81,10 @@ class DynamicAggregateTest extends AbstractElasticsearchTestCase
                                 'value' => 'Lithuania',
                             ],
                             [
+                                'name' => 'Designed in',
+                                'value' => 'USA',
+                            ],
+                            [
                                 'name' => 'Color',
                                 'value' => 'Green',
                             ]
@@ -101,6 +109,10 @@ class DynamicAggregateTest extends AbstractElasticsearchTestCase
                             [
                                 'name' => 'Made in',
                                 'value' => 'USA',
+                            ],
+                            [
+                                'name' => 'Designed in',
+                                'value' => 'Germany',
                             ],
                             [
                                 'name' => 'Color',
@@ -163,6 +175,10 @@ class DynamicAggregateTest extends AbstractElasticsearchTestCase
                                 'value' => 'China',
                             ],
                             [
+                                'name' => 'Designed in',
+                                'value' => 'USA',
+                            ],
+                            [
                                 'name' => 'Group',
                                 'value' => 'Utilities',
                             ]
@@ -174,6 +190,10 @@ class DynamicAggregateTest extends AbstractElasticsearchTestCase
                             [
                                 'name' => 'Made in',
                                 'value' => 'China',
+                            ],
+                            [
+                                'name' => 'Designed in',
+                                'value' => 'Germany',
                             ],
                             [
                                 'name' => 'Color',
@@ -227,6 +247,10 @@ class DynamicAggregateTest extends AbstractElasticsearchTestCase
                     'Germany' => 3,
                     'Lithuania' => 1,
                 ],
+                'Designed in' => [
+                    'USA' => 3,
+                    'Germany' => 2,
+                ],
                 'Condition' => [
                     'Excelent' => 2,
                     'Fair' => 2,
@@ -274,6 +298,10 @@ class DynamicAggregateTest extends AbstractElasticsearchTestCase
                     'USA' => 1,
                     'China' => 1,
                     'Lithuania' => 0,
+                    'Germany' => 0,
+                ],
+                'Designed in' => [
+                    'USA' => 1,
                     'Germany' => 0,
                 ],
                 'Condition' => [

--- a/Tests/Functional/Filter/Widget/Dynamic/DynamicAggregateTest.php
+++ b/Tests/Functional/Filter/Widget/Dynamic/DynamicAggregateTest.php
@@ -265,7 +265,7 @@ class DynamicAggregateTest extends AbstractElasticsearchTestCase
             'filter' => 'dynamic_aggregate_filter'
         ];
 
-        // Case #0, with color red
+        // Case #1, with color red
         $out[] = [
             'request' => new Request(['dynamic_aggregate' => ['Color' => 'Red']]),
             'expectedChoices' => [
@@ -280,12 +280,15 @@ class DynamicAggregateTest extends AbstractElasticsearchTestCase
                 ],
                 'Condition' => [
                     'Fair' => 1,
+                ],
+                'Designed in' => [
+                    'Germany' => 2,
                 ]
             ],
             'filter' => 'dynamic_aggregate_filter'
         ];
 
-        // Case #0, with color red, with zero choices
+        // Case #2, with color red, with zero choices
         $out[] = [
             'request' => new Request(['zero_aggregate' => ['Color' => 'Red']]),
             'expectedChoices' => [
@@ -301,8 +304,8 @@ class DynamicAggregateTest extends AbstractElasticsearchTestCase
                     'Germany' => 0,
                 ],
                 'Designed in' => [
-                    'USA' => 1,
-                    'Germany' => 0,
+                    'USA' => 0,
+                    'Germany' => 2,
                 ],
                 'Condition' => [
                     'Fair' => 1,


### PR DESCRIPTION
This PR fixes the malfunctioning of the filter when same values are present with different group names, also, corrects the formation of zero choices when only other filters are applied and, because the 'all-selected' part of the `$unsortedChoices` array is no longer being created, the functioning of the filter should be a bit faster as well

Closes #202 #199 
