### PR TITLE
Twig_SimpleFunction is deprecated and should not be used.

### DIFF
--- a/Twig/PagerExtension.php
+++ b/Twig/PagerExtension.php
@@ -43,12 +43,12 @@ class PagerExtension extends \Twig_Extension
     public function getFunctions()
     {
         return [
-            new \Twig_Function(
+            new \Twig_SimpleFunction(
                 'ongr_paginate',
                 [$this, 'paginate'],
                 ['is_safe' => ['html'], 'needs_environment' => true]
             ),
-            new \Twig_Function('ongr_paginate_path', [$this, 'path'], ['is_safe' => []]),
+            new \Twig_SimpleFunction('ongr_paginate_path', [$this, 'path'], ['is_safe' => []]),
         ];
     }
 


### PR DESCRIPTION
`Twig_SimpleFunction` is deprecated and already removed in Twig `2.0`