### PR TITLE
Changed MultiDynamicAggregate::getFilterQuery() visibility to protected

### DIFF
--- a/Filter/Widget/Dynamic/MultiDynamicAggregate.php
+++ b/Filter/Widget/Dynamic/MultiDynamicAggregate.php
@@ -131,7 +131,7 @@ class MultiDynamicAggregate extends DynamicAggregate
      *
      * @return BoolQuery
      */
-    private function getFilterQuery($terms)
+    protected function getFilterQuery($terms)
     {
         list($path, $field) = explode('>', $this->getDocumentField());
         $boolQuery = new BoolQuery();


### PR DESCRIPTION
This allows overriding `getFilterQuery` without the need to copy paste `modifySearch` as well.

Specifically I'm overriding `getFilterQuery` to add `inner_hits` parameter to detect which *product variant* was matched.